### PR TITLE
Fix SRI placeholders

### DIFF
--- a/avisos.html
+++ b/avisos.html
@@ -11,13 +11,13 @@
   <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
   <link rel="preload" as="style"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-        integrity="sha384-…" crossorigin="anonymous"
+        crossorigin="anonymous"
         onload="this.rel='stylesheet'">
   <!-- Fallback si JS está deshabilitado -->
   <noscript>
     <link rel="stylesheet"
           href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-          integrity="sha384-…" crossorigin="anonymous">
+          crossorigin="anonymous">
   </noscript>
 
   <!-- Bootstrap Icons: iconos SVG listos para usar -->
@@ -106,7 +106,7 @@
 
   <!-- Bootstrap JS: habilita componentes interactivos (navbar, collapse, etc.) -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
-          integrity="sha384-…" crossorigin="anonymous" defer></script>
+          crossorigin="anonymous" defer></script>
   
   <!--Script de validación y modo claro/oscuro -->
   <script src="js/script.js" defer></script>

--- a/contacto.html
+++ b/contacto.html
@@ -10,11 +10,11 @@
   <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
   <link rel="preload" as="style"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-        integrity="sha384-…" crossorigin="anonymous" onload="this.rel='stylesheet'">
+        crossorigin="anonymous" onload="this.rel='stylesheet'">
   <noscript>
     <link rel="stylesheet"
           href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-          integrity="sha384-…" crossorigin="anonymous">
+          crossorigin="anonymous">
   </noscript>
 
   <!-- Bootstrap Icons -->
@@ -90,7 +90,7 @@
 
   <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
-          integrity="sha384-…" crossorigin="anonymous" defer></script>
+          crossorigin="anonymous" defer></script>
   <!-- Script de validación y modo claro/oscuro -->
   <script src="js/script.js" defer></script>
 </body>

--- a/disenoweb.html
+++ b/disenoweb.html
@@ -7,7 +7,7 @@
     <!-- Precarga de CSS de Bootstrap para mejorar rendimiento -->
   <link rel="preload" as="style"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-        integrity="sha384-…" crossorigin="anonymous"
+        crossorigin="anonymous"
         onload="this.rel='stylesheet'">
   <link rel="stylesheet" href="css/disenoweb.css">
 </head>
@@ -278,7 +278,7 @@
 
 <!-- Script de Bootstrap para habilitar funcionalidades como el colapso del navbar -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-…" crossorigin="anonymous" defer></script>
+        crossorigin="anonymous" defer></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,13 +13,13 @@
   <!-- Precarga de CSS de Bootstrap para mejorar rendimiento -->
   <link rel="preload" as="style"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-        integrity="sha384-…" crossorigin="anonymous"
+        crossorigin="anonymous"
         onload="this.rel='stylesheet'">
   <!-- Fallback para navegadores sin JavaScript -->
   <noscript>
     <link rel="stylesheet"
           href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-          integrity="sha384-…" crossorigin="anonymous">
+          crossorigin="anonymous">
   </noscript>
 
   <!-- Bootstrap Icons: biblioteca de iconos SVG compatibles con Bootstrap -->
@@ -179,7 +179,7 @@
 
   <!-- Script de Bootstrap para habilitar funcionalidades como el colapso del navbar -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
-          integrity="sha384-…" crossorigin="anonymous" defer></script>
+          crossorigin="anonymous" defer></script>
     <!--Script de validación y modo claro/oscuro -->
   <script src="js/script.js" defer></script>
 </body>

--- a/materias2025.html
+++ b/materias2025.html
@@ -11,13 +11,13 @@
   <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
   <link rel="preload" as="style"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-        integrity="sha384-…" crossorigin="anonymous"
+        crossorigin="anonymous"
         onload="this.rel='stylesheet'">
   <!-- Fallback para usuarios sin JS -->
   <noscript>
     <link rel="stylesheet"
           href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-          integrity="sha384-…" crossorigin="anonymous">
+          crossorigin="anonymous">
   </noscript>
 
   <!-- Iconos de Bootstrap (SVG font) -->
@@ -200,7 +200,7 @@
 
   <!-- Script de Bootstrap para funcionalidades JS (collapse, etc.) -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
-          integrity="sha384-…" crossorigin="anonymous" defer></script>
+          crossorigin="anonymous" defer></script>
     <!-- Script de validación y modo claro/oscuro -->
   <script src="js/script.js" defer></script>
 </body>

--- a/sobremi.html
+++ b/sobremi.html
@@ -11,11 +11,11 @@
   <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
   <link rel="preload" as="style"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-        integrity="sha384-…" crossorigin="anonymous" onload="this.rel='stylesheet'">
+        crossorigin="anonymous" onload="this.rel='stylesheet'">
   <noscript>
     <link rel="stylesheet"
           href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-          integrity="sha384-…" crossorigin="anonymous">
+          crossorigin="anonymous">
   </noscript>
 
   <!-- Bootstrap Icons -->
@@ -134,7 +134,7 @@
   </div>
   <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
-          integrity="sha384-…" crossorigin="anonymous" defer></script>
+          crossorigin="anonymous" defer></script>
   <!--Script de validación y modo claro/oscuro -->
   <script src="js/script.js" defer></script>
   


### PR DESCRIPTION
## Summary
- remove `integrity` attributes that used placeholder values so CDN files load correctly

## Testing
- `grep -R "sha384-" -n --include="*.html" .`

------
https://chatgpt.com/codex/tasks/task_e_6849e1ade350832c97b1997630c921cc