### PR TITLE
Add Inter font site-wide

### DIFF
--- a/avisos.html
+++ b/avisos.html
@@ -11,6 +11,9 @@
   <!-- Preconexión y precarga de Bootstrap CSS -->
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+
+  <!-- Google Font -->
+  <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
   <link rel="preload" as="style"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
         crossorigin="anonymous"

--- a/contacto.html
+++ b/contacto.html
@@ -10,6 +10,9 @@
   <!-- Bootstrap CSS -->
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+
+  <!-- Google Font -->
+  <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
   <link rel="preload" as="style"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
         crossorigin="anonymous" onload="this.rel='stylesheet'">

--- a/css/disenoweb.css
+++ b/css/disenoweb.css
@@ -16,7 +16,7 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  font-family: Arial, sans-serif;
+  font-family: 'Inter', sans-serif;
   background: #ffffff;
   color: #333333;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -45,6 +45,7 @@
 body {
   background-color: var(--bg-page);
   color:            var(--text-page);
+  font-family:      'Inter', sans-serif;
   display: flex;
   flex-direction: column;
   min-height: 100vh;

--- a/disenoweb.html
+++ b/disenoweb.html
@@ -6,6 +6,8 @@
   <meta name="description" content="Resumen del curso Diseño y Desarrollo Web.">
   <link rel="icon" href="assets/image.jpg" type="image/jpeg">
   <title>Diseño y Desarrollo Web</title>
+  <!-- Google Font -->
+  <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
     <!-- Precarga de CSS de Bootstrap para mejorar rendimiento -->
   <link rel="preload" as="style"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"

--- a/index.html
+++ b/index.html
@@ -12,6 +12,9 @@
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
 
+  <!-- Google Font -->
+  <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
+
   <!-- Precarga de CSS de Bootstrap para mejorar rendimiento -->
   <link rel="preload" as="style"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"

--- a/materias2025.html
+++ b/materias2025.html
@@ -11,6 +11,9 @@
   <!-- Preconexión y precarga de Bootstrap CSS para rendimiento -->
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+
+  <!-- Google Font -->
+  <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
   <link rel="preload" as="style"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
         crossorigin="anonymous"

--- a/sobremi.html
+++ b/sobremi.html
@@ -11,6 +11,9 @@
   <!-- Bootstrap CSS -->
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+
+  <!-- Google Font -->
+  <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
   <link rel="preload" as="style"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
         crossorigin="anonymous" onload="this.rel='stylesheet'">


### PR DESCRIPTION
## Summary
- load Google Font Inter in all HTML pages
- set Inter as the base font in style.css
- update disenoweb.css to use the same font

## Testing
- `python3 -m http.server 8000` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_684a03ae3f18832c8d01fafcd376ab20