### PR TITLE
Fix HTML injection in contact form

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -38,6 +38,18 @@ document.addEventListener('DOMContentLoaded', () => {
       return re.test(email);
     }
 
+    /**
+     * Escapes HTML entities to prevent injection
+     * @param {string} str
+     * @returns {string}
+     */
+    function escapeHTML(str) {
+      return str.replace(/[&<>"']/g, c => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;',
+        '"': '&quot;', "'": '&#39;'
+      })[c]);
+    }
+
     form.addEventListener('submit', (event) => {
       event.preventDefault();
       msgContainer.innerHTML = '';
@@ -69,7 +81,7 @@ document.addEventListener('DOMContentLoaded', () => {
       } else {
         msgContainer.innerHTML = `
           <div class="alert alert-success" role="alert">
-            Gracias por su contacto, <strong>${nombre}</strong>.<br>
+            Gracias por su contacto, <strong>${escapeHTML(nombre)}</strong>.<br>
             En breve le estaré respondiendo.
           </div>`;
         form.reset();


### PR DESCRIPTION
## Summary
- add `escapeHTML` helper and sanitize name

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684a05d50f24832c8c2ace4009e7704d