### PR TITLE
Add night mode to Diseño Web page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -280,8 +280,8 @@ body.disenoweb {
   flex-direction: column;
   min-height: 100vh;
   font-family: 'Inter', sans-serif;
-  background: #ffffff;
-  color: #333333;
+  background: var(--bg-page);
+  color: var(--text-page);
 }
 body.disenoweb main {
   flex: 1;
@@ -314,15 +314,15 @@ body.disenoweb .derecha {
 body.disenoweb .fechas,
 body.disenoweb .bibliografia,
 body.disenoweb .actividades {
-  background: #f5f7fa;
+  background: var(--bg-section);
   padding: 20px;
-  border: 1px solid #dadde1;
+  border: 1px solid var(--border-color);
   border-radius: 12px;
 }
 body.disenoweb .fechas ul li,
 body.disenoweb .bibliografia ul li {
   padding: 12px 8px;
-  border-bottom: 1px solid #c5dbf0;
+  border-bottom: 1px solid var(--border-color);
   line-height: 1.8;
   font-size: 1.05rem;
   display: flex;
@@ -347,8 +347,8 @@ body.disenoweb .icono {
   font-size: 1.2rem;
 }
 body.disenoweb .actividad {
-  background: #ffffff;
-  border: 1px solid #dadde1;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
   border-radius: 12px;
   padding: 20px;
   margin-bottom: 15px;
@@ -357,7 +357,7 @@ body.disenoweb .actividad {
 body.disenoweb .actividad:hover {
   box-shadow: 0 8px 20px rgba(0,0,0,0.15);
   transform: translateY(-5px);
-  background: #f0f8ff;
+  background: var(--bg-section);
 }
 body.disenoweb .contenido-actividad {
   display: flex;
@@ -397,13 +397,13 @@ body.disenoweb .btn:hover {
   background: #005bb5;
 }
 body.disenoweb footer {
-  background: #003366;
+  background: var(--bg-nav);
   text-align: center;
   padding: 10px;
-  color: #ffffff;
+  color: var(--text-nav);
 }
 body.disenoweb .navbar {
-  background-color: #0d6efd !important;
+  background-color: var(--bg-nav) !important;
 }
 @media (max-width: 768px) {
   body.disenoweb .contenedor-principal {

--- a/disenoweb.html
+++ b/disenoweb.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="es" data-theme="light">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -8,40 +8,42 @@
   <title>Diseño y Desarrollo Web</title>
   <!-- Google Font -->
   <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
-    <!-- Precarga de CSS de Bootstrap para mejorar rendimiento -->
+  <!-- Precarga de CSS de Bootstrap para mejorar rendimiento -->
   <link rel="preload" as="style"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
         crossorigin="anonymous"
         onload="this.rel='stylesheet'">
+  <!-- Bootstrap Icons -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet" crossorigin="anonymous">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body class="disenoweb">
   <a href="#main-content" class="visually-hidden-focusable">Saltar al contenido</a>
 
   <!-- Navbar -->
-  <nav 
-    class="navbar navbar-expand-lg navbar-dark bg-dark shadow-sm" 
-    aria-label="Menú principal">
-    <div class="container">
+  <nav
+    class="navbar navbar-expand-lg shadow-sm"
+    aria-label="Menú principal" style="background-color: var(--bg-nav);">
+    <div class="container d-flex align-items-center">
       <!-- .container: centra y limita el ancho del contenido -->
-      <a class="navbar-brand" href="index.html">
+      <a class="navbar-brand text-white" href="index.html">
         <!-- .navbar-brand: estilo especial para el nombre o logo -->
         Mi Cursada 2025
       </a>
-      <button 
-        class="navbar-toggler" 
-        type="button" 
-        data-bs-toggle="collapse" 
-        data-bs-target="#navbarNav" 
-        aria-controls="navbarNav" 
-        aria-expanded="false" 
+      <button
+        class="navbar-toggler ms-2"
+        type="button"
+        data-bs-toggle="collapse"
+        data-bs-target="#navbarNav"
+        aria-controls="navbarNav"
+        aria-expanded="false"
         aria-label="Alternar navegación">
         <!-- .navbar-toggler: botón que aparece en pantallas pequeñas -->
         <span class="navbar-toggler-icon"></span>
         <!-- .navbar-toggler-icon: icono estándar de hamburguesa -->
       </button>
 
-      <div class="collapse navbar-collapse" id="navbarNav">
+      <div class="collapse navbar-collapse flex-fill justify-content-center" id="navbarNav">
         <!-- .collapse.navbar-collapse: menú colapsable que se muestra/oculta -->
         <ul class="navbar-nav ms-auto">
           <!-- .navbar-nav: contenedor de enlaces
@@ -55,6 +57,14 @@
           <li class="nav-item"><a class="nav-link active" aria-current="page" href="materias2025.html">Materias 2025</a></li>
           <li class="nav-item"><a class="nav-link" href="contacto.html">Contacto</a></li>
         </ul>
+      </div>
+      <div class="d-flex align-items-center ms-auto">
+        <button id="btn-light" class="btn btn-outline-light btn-sm me-2" aria-label="Modo claro">
+          <i class="bi bi-sun-fill" aria-hidden="true"></i>
+        </button>
+        <button id="btn-dark" class="btn btn-outline-light btn-sm" aria-label="Modo oscuro">
+          <i class="bi bi-moon-fill" aria-hidden="true"></i>
+        </button>
       </div>
     </div>
   </nav>
@@ -280,6 +290,8 @@
 <!-- Script de Bootstrap para habilitar funcionalidades como el colapso del navbar -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
         crossorigin="anonymous" defer></script>
+  <!-- Script de modo claro/oscuro -->
+  <script src="js/script.js" defer></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable theme toggling on `disenoweb.html`
- load Bootstrap Icons and JavaScript for theme switch
- adjust Diseño Web styles to use CSS variables for dark mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a083ca9ec832ca1aef147dfad9f45