### PR TITLE
Update theme toggle styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -456,15 +456,13 @@ body.disenoweb .navbar {
 /* Reserva espacio para el toggle de tema y evita    */
 /* ------------------------------------------------- */
 .theme-toggle-container {
-  width: 3rem;        /* ajusta según el gap deseado */
-  min-width: 3rem;    /* nunca colapsa */
-  justify-content: space-between;
+  gap: 0.5rem;
 }
 
 .theme-toggle-container button {
   background: none;
   border: none;
-  font-size: 1.25rem; /* tamaño de icono */
-  padding: 0;
+  font-size: 1rem; /* tamaño de icono */
+  padding: 0.25rem;
   cursor: pointer;
 }

--- a/disenoweb.html
+++ b/disenoweb.html
@@ -79,13 +79,9 @@
         </ul>
       </div>
       <!-- Derecha: toggle tema -->
-      <div class="d-flex align-items-center ms-auto">
-        <button id="btn-light" class="btn btn-outline-light btn-sm me-2" aria-label="Modo claro">
-          <i class="bi bi-sun-fill" aria-hidden="true"></i>
-        </button>
-        <button id="btn-dark" class="btn btn-outline-light btn-sm" aria-label="Modo oscuro">
-          <i class="bi bi-moon-fill" aria-hidden="true"></i>
-        </button>
+      <div class="theme-toggle-container d-flex align-items-center ms-auto">
+        <button id="btn-light" aria-label="Modo claro"><i class="bi bi-sun-fill" aria-hidden="true"></i></button>
+        <button id="btn-dark" aria-label="Modo oscuro"><i class="bi bi-moon-fill" aria-hidden="true"></i></button>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
- simplify `.theme-toggle-container` styles and use gap spacing
- reduce theme toggle button size
- unify markup for theme toggle on Diseño Web page

## Testing
- `node -c js/script.js`

------
https://chatgpt.com/codex/tasks/task_e_684cb5358628832ca4e1e2eae04ff857