### PR TITLE
Fix script path separators

### DIFF
--- a/avisos.html
+++ b/avisos.html
@@ -132,6 +132,6 @@
           crossorigin="anonymous" defer></script>
   
   <!--Script de validación y modo claro/oscuro -->
-  <script src="js\script.js" defer></script>
+  <script src="js/script.js" defer></script>
 </body>
 </html>

--- a/contacto.html
+++ b/contacto.html
@@ -117,6 +117,6 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
           crossorigin="anonymous" defer></script>
   <!-- Script de validación y modo claro/oscuro -->
-  <script src="js\script.js" defer></script>
+  <script src="js/script.js" defer></script>
 </body>
 </html>

--- a/disenoweb.html
+++ b/disenoweb.html
@@ -315,7 +315,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
         crossorigin="anonymous" defer></script>
   <!-- Script de modo claro/oscuro -->
-  <script src="js\script.js" defer></script>
+  <script src="js/script.js" defer></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -202,6 +202,6 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
           crossorigin="anonymous" defer></script>
     <!--Script de validación y modo claro/oscuro -->
-  <script src="js\script.js" defer></script>
+  <script src="js/script.js" defer></script>
 </body>
 </html>

--- a/materias2025.html
+++ b/materias2025.html
@@ -223,6 +223,6 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
           crossorigin="anonymous" defer></script>
     <!-- Script de validación y modo claro/oscuro -->
-  <script src="js\script.js" defer></script>
+  <script src="js/script.js" defer></script>
 </body>
 </html>

--- a/sobremi.html
+++ b/sobremi.html
@@ -139,7 +139,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
           crossorigin="anonymous" defer></script>
   <!--Script de validación y modo claro/oscuro -->
-   <script src="js\script.js" defer></script>
+   <script src="js/script.js" defer></script>
   
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update HTML pages to use forward slashes for script paths

## Testing
- `grep -n "js/script.js" *.html`

------
https://chatgpt.com/codex/tasks/task_e_684cb535dc5c832c9e6020591441c226