### PR TITLE
Improve navbar layout on small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -466,3 +466,19 @@ body.disenoweb .navbar {
   padding: 0.25rem;
   cursor: pointer;
 }
+@media (max-width: 576px) {
+  .navbar .navbar-brand {
+    font-size: 1rem;
+    margin-right: .5rem;
+  }
+  .navbar-toggler {
+    padding: 0.25rem 0.5rem;
+    font-size: 1rem;
+  }
+  .theme-toggle-container {
+    gap: 0.25rem;
+  }
+  .theme-toggle-container button {
+    font-size: 0.875rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive CSS to keep navbar content on one line on small screens

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cba044690832cb97676cf3f5faea9