### PR TITLE
Hide theme buttons with open mobile menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -487,3 +487,10 @@ body.disenoweb .navbar {
     font-size: 0.875rem;
   }
 }
+
+/* Oculta los botones de tema cuando se abre el menú hamburguesa */
+@media (max-width: 768px) {
+  .navbar-collapse.show + .theme-toggle-container {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- hide light/dark mode buttons when hamburger menu is expanded on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cbbacc4b4832cbff75cafc9aec8a6